### PR TITLE
Added functionality to display invariant mass of the two leading jets…

### DIFF
--- a/Code/Headers/Generic_Functions.h
+++ b/Code/Headers/Generic_Functions.h
@@ -30,7 +30,12 @@ void DrawHistogram(TH1F *histogram, string canvasName, string histogramName, str
 	//Write out to a PDF file
 	canvas->SaveAs(FullOutputFilePath.c_str());
 
+	canvas->Close();
+
 }
+
+
+/////////////////////////////-------------THIS FUNCTION IS DEPRECATED, PLEASE REMOVE FROM ANY ANALYSES----------/////////////////////////////////////////////////////////////////
 
 //This function will draw a generic histogram, for simple histograms, it will be faster to use this
 //Draw histogram function takes the following:
@@ -60,7 +65,7 @@ void DrawHistogram_OldCanvas(TH1F *histogram, string canvasName, string histogra
 
 }
 
-
+//////////////////////////////////////////-----------------------------------------------------------------------/////////////////////////////////////////////////////////////////
 
 //This Fucntion will calculate invariant mass of two TLorentzVectors
 double InvariantMass(TLorentzVector *Vector1, TLorentzVector *Vector2) {
@@ -91,6 +96,14 @@ double DeltaRCalc(TLorentzVector *Vector1, TLorentzVector *Vector2) {
 
 	double DeltaRVal = sqrt( pow(DeltaPhi(Vector1, Vector2), 2) + pow(DeltaEta(Vector1, Vector2), 2) );
 	return DeltaRVal;
+
+}
+
+//This Function will calculate combined transverse momentum
+double CombinedTransverseMomentum(TLorentzVector *Vector1, TLorentzVector *Vector2) {
+
+	double pT = ((*Vector1)+(*Vector2)).Pt();
+	return pT;
 
 }
 

--- a/Code/Headers/Histo_Book_Definitions_Custom.h
+++ b/Code/Headers/Histo_Book_Definitions_Custom.h
@@ -23,6 +23,7 @@
 /// -------- RECYCLABLE VARIABLES ------ ///
 
 ///----------Delta R---------------------------------///
+
 /// -- Variable to be plotted in histogram
 double DeltaR;
 
@@ -33,6 +34,21 @@ TH1F	*h_DeltaR;
 /// -- Virtual book function to book the histogram (PRE version)
 virtual void Book_DeltaR_PRE(int bins, double min, double max);
 TH1F	*h_DeltaR_PRE;
+
+///----------- Leading Jets Invariant Mass ------------///
+
+///Leading jets invariant mass
+double ljet_0_ljet_1_mass; 
+
+/// -- Virtual book function to book the histogram
+virtual void Book_ljet_0_ljet_1_mass(int bins, double min, double max);
+/// -- Declaration of Histogram
+TH1F	*h_ljet_0_ljet_1_mass;
+
+/// -- Virtual book function to book the histogram (PRE version)
+virtual void Book_ljet_0_ljet_1_mass_PRE(int bins, double min, double max);
+/// -- Declaration of Histogram (PRE version)
+TH1F	*h_ljet_0_ljet_1_mass_PRE;
 
 
 /// ----------- ELECTRONS ------------- ///

--- a/Code/Headers/Histo_Book_Functions_Custom.h
+++ b/Code/Headers/Histo_Book_Functions_Custom.h
@@ -63,5 +63,19 @@ void MC_Analysis::Book_muon_0_muon_1_mass_PRE(int bins, double min, double max) 
 	h_muon_0_muon_1_mass_PRE = new TH1F("h_muon_0_muon_1_mass_PRE", "", bins, min, max);
 }
 
+/// ---------- JETS --------------///
+
+//Function for booking leading jets invariant mass
+void MC_Analysis::Book_ljet_0_ljet_1_mass(int bins, double min, double max) {
+	h_ljet_0_ljet_1_mass = new TH1F("h_ljet_0_ljet_1_mass", "", bins, min, max);
+}
+
+//Function for booking leading jets invariant mass
+void MC_Analysis::Book_ljet_0_ljet_1_mass_PRE(int bins, double min, double max) {
+	h_ljet_0_ljet_1_mass_PRE = new TH1F("h_ljet_0_ljet_1_mass_PRE", "", bins, min, max);
+}
+
+
+
 
 #endif


### PR DESCRIPTION
…, and then uses that information to cut away dilepton jets with low invariant mass. Also made DrawHistogram function immediately close the open canvas upon completion, making _OldCanvas version obselete. Make sure to remove all uses of _OldCanvas from future analyses