### PR TITLE
muon and electron analysis mirrored now

### DIFF
--- a/Code/Headers/Histo_Book_Definitions_Custom.h
+++ b/Code/Headers/Histo_Book_Definitions_Custom.h
@@ -61,7 +61,7 @@ TH1F	*h_ljet_0_ljet_1_mass_PRE;
 
 ///-------------Invariant mass of electron 0 and electron 1-----------------///
 /// -- Variable to be plotted in histogram
-double elec_0_elec_1_Mass;
+double elec_0_elec_1_mass;
 
 /// -- Virtual book function to book the histogram
 virtual void Book_elec_0_elec_1_mass(int bins, double min, double max);
@@ -89,14 +89,11 @@ TH1F	*h_elec_0_elec_1_pt_PRE;
 
 
 
-
-
-
 /// ----------- MUONS ------------- ///
 
 ///-------------Invariant mass of muon 0 and muon 1-----------------///
 /// -- Variable to be plotted in histogram
-double muon_0_muon_1_Mass;
+double muon_0_muon_1_mass;
 
 /// -- Virtual book function to book the histogram
 virtual void Book_muon_0_muon_1_mass(int bins, double min, double max);
@@ -105,6 +102,20 @@ TH1F	*h_muon_0_muon_1_mass;
 /// -- Virtual book function to book the histogram (PRE version)
 virtual void Book_muon_0_muon_1_mass_PRE(int bins, double min, double max);
 TH1F	*h_muon_0_muon_1_mass_PRE;
+
+/////---------------------muon_0 & muon_1 combined pt---------------------/////
+/// -- Variable to be plotted in histogram
+double muon_0_muon_1_pt;
+
+/// -- Virtual book function to book the histogram
+virtual void Book_muon_0_muon_1_pt(int bins, double min, double max);
+/// -- Declaration of Histogram
+TH1F	*h_muon_0_muon_1_pt;
+
+/// -- Virtual book function to book the histogram (PRE version)
+virtual void Book_muon_0_muon_1_pt_PRE(int bins, double min, double max);
+/// -- Declaration of Histogram (PRE version)
+TH1F	*h_muon_0_muon_1_pt_PRE;
 
 
 

--- a/Code/Headers/Zee2Jets_Analysis.h
+++ b/Code/Headers/Zee2Jets_Analysis.h
@@ -105,7 +105,7 @@ bool MC_Analysis::Zee2Jets_InitialCut() {
 void MC_Analysis::Zee2Jets_GenerateVariables() {
 
 	//Invariant Mass
-	elec_0_elec_1_Mass = InvariantMass(elec_0_p4, elec_1_p4);
+	elec_0_elec_1_mass = InvariantMass(elec_0_p4, elec_1_p4);
 	ljet_0_ljet_1_mass = InvariantMass(ljet_0_p4, ljet_1_p4);
 
 	//Delta R
@@ -117,11 +117,11 @@ void MC_Analysis::Zee2Jets_GenerateVariables() {
 
 }
 
-//Rhis function will fill the histograms that need to be filled before cuts are made
+// This function will fill the histograms that need to be filled before cuts are made
 void MC_Analysis::Zee2Jets_FillAllData_PreCut() {
 
 	//Invariant mass
-	h_elec_0_elec_1_mass_PRE->Fill(elec_0_elec_1_Mass);
+	h_elec_0_elec_1_mass_PRE->Fill(elec_0_elec_1_mass);
 	h_ljet_0_ljet_1_mass_PRE->Fill(ljet_0_ljet_1_mass);
 
 	//Combined lepton pt
@@ -147,8 +147,10 @@ bool MC_Analysis::Zee2Jets_Cut() {
 	bool ljet_0_pt_greater = false;
 	bool ljet_1_pt_greater = false;
 	bool ljet_2_pt_less = false;
-
+	
 	//Condition Checking
+
+	// search region cuts from Section 6, page 7, REF: ATLAS doi:10.1007/JHEP04(2014)031
 	if (ljet_0_ljet_1_mass > 250) leading_jets_invariant_mass = true;
 	if (ljet_0_p4->Pt() > 50) ljet_0_pt_greater = true;
 	if (ljet_1_p4->Pt() > 50) ljet_1_pt_greater = true;
@@ -177,14 +179,19 @@ void MC_Analysis::Zee2Jets_FillAllData_PostCut() {
 	h_elec_0_p4_Pt->Fill(elec_0_p4->Pt());
 
 	//Invariant mass
-	h_elec_0_elec_1_mass->Fill(elec_0_elec_1_Mass);
-	h_ljet_0_ljet_1_mass->Fill(ljet_0_ljet_1_mass);
+	h_elec_0_elec_1_mass->Fill(elec_0_elec_1_mass); // two electrons
+	h_ljet_0_ljet_1_mass->Fill(ljet_0_ljet_1_mass); // two jets
 
-	//Combined lepton pt
+	//Combined lepton (electron) pT
 	h_elec_0_elec_1_pt->Fill(elec_0_elec_1_pt);
 
 	//Delta R for two electrons
 	h_DeltaR->Fill(DeltaR);
+
+	//ljet transverse momenta
+	h_ljet_0_p4_Pt->Fill(ljet_0_p4->Pt());
+	h_ljet_1_p4_Pt->Fill(ljet_1_p4->Pt());
+	h_ljet_2_p4_Pt->Fill(ljet_2_p4->Pt());
 
 	//Electron Rapidity
 	h_elec_0_p4_Rapidity->Fill(elec_0_p4->Rapidity());
@@ -195,11 +202,6 @@ void MC_Analysis::Zee2Jets_FillAllData_PostCut() {
 	h_ljet_1_p4_Rapidity->Fill(ljet_1_p4->Rapidity());
 	h_ljet_2_p4_Rapidity->Fill(ljet_2_p4->Rapidity());
 	h_ljet_3_p4_Rapidity->Fill(ljet_3_p4->Rapidity());
-
-	//ljet transverse momenta
-	h_ljet_0_p4_Pt->Fill(ljet_0_p4->Pt());
-	h_ljet_1_p4_Pt->Fill(ljet_1_p4->Pt());
-	h_ljet_2_p4_Pt->Fill(ljet_2_p4->Pt());
 
 }
 
@@ -231,7 +233,6 @@ void MC_Analysis::Zee2Jets_DrawHistos() {
 	DrawHistogram(h_elec_0_elec_1_mass_PRE, "h_elec_0_elec_1_mass_PRE", "h_elec_0_elec_1_mass_PRE_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_elec_0_elec_1_mass_PRE_Zee2Jets.pdf", AnalysisType);
 	DrawHistogram(h_elec_0_elec_1_mass, "h_elec_0_elec_1_mass", "h_elec_0_elec_1_mass_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_elec_0_elec_1_mass_Zee2Jets.pdf", AnalysisType);
 
-
 	//Elec 0 & Elec 1 histograms
 	DrawHistogram(h_elec_0_elec_1_mass_PRE, "h_elec_0_elec_1_mass_PRE", "h_elec_0_elec_1_mass_PRE_Zee2Jets", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_elec_0_elec_1_mass_PRE_Zee2Jets.pdf", AnalysisType);
 	DrawHistogram(h_elec_0_elec_1_mass, "h_elec_0_elec_1_mass", "h_elec_0_elec_1_mass_Zee2Jets", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_elec_0_elec_1_mass_Zee2Jets.pdf", AnalysisType);
@@ -245,14 +246,14 @@ void MC_Analysis::Zee2Jets_DrawHistos() {
 	DrawHistogram(h_ljet_0_ljet_1_mass, "h_ljet_0_ljet_1_mass", "h_ljet_0_ljet_1_mass_Zee2Jets", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_ljet_0_ljet_1_mass_Zee2Jets.pdf", AnalysisType);
 
 	//ljet transverse momenta
-	DrawHistogram(h_ljet_0_p4_Pt, "h_ljet_0_p4_Pt", "h_ljet_0_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_0_p4_Pt_Zee2Jets.pdf", AnalysisType);
-	DrawHistogram(h_ljet_1_p4_Pt, "h_ljet_1_p4_Pt", "h_ljet_1_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_1_p4_Pt_Zee2Jets.pdf", AnalysisType);
-	DrawHistogram(h_ljet_2_p4_Pt, "h_ljet_2_p4_Pt", "h_ljet_2_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_2_p4_Pt_Zee2Jets.pdf", AnalysisType);
-
+	// PRE selection cuts
 	DrawHistogram(h_ljet_0_p4_Pt_PRE, "h_ljet_0_p4_Pt_PRE", "h_ljet_0_p4_Pt_PRE_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_0_p4_Pt_PRE_Zee2Jets.pdf", AnalysisType);
 	DrawHistogram(h_ljet_1_p4_Pt_PRE, "h_ljet_1_p4_Pt_PRE", "h_ljet_1_p4_Pt_PRE_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_1_p4_Pt_PRE_Zee2Jets.pdf", AnalysisType);
 	DrawHistogram(h_ljet_2_p4_Pt_PRE, "h_ljet_2_p4_Pt_PRE", "h_ljet_2_p4_Pt_PRE_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_2_p4_Pt_PRE_Zee2Jets.pdf", AnalysisType);
-	
+	// Post selection cuts
+	DrawHistogram(h_ljet_0_p4_Pt, "h_ljet_0_p4_Pt", "h_ljet_0_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_0_p4_Pt_Zee2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_1_p4_Pt, "h_ljet_1_p4_Pt", "h_ljet_1_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_1_p4_Pt_Zee2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_2_p4_Pt, "h_ljet_2_p4_Pt", "h_ljet_2_p4_Pt_Zee2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_2_p4_Pt_Zee2Jets.pdf", AnalysisType);
 }
 
 #endif

--- a/Code/Headers/Zmumu2Jets_Analysis.h
+++ b/Code/Headers/Zmumu2Jets_Analysis.h
@@ -60,6 +60,21 @@ void MC_Analysis::Zmumu2Jets_BookHistos() {
 	//Delta R PRE
 	Book_DeltaR_PRE(bins, 0, 10);
 
+	///---------------------------ljet transverse momentum--------------------------------///
+
+	Book_ljet_0_p4_Pt(bins, 0, 300);
+	Book_ljet_1_p4_Pt(bins, 0, 300);
+	Book_ljet_2_p4_Pt(bins, 0, 300);
+
+	Book_ljet_0_p4_Pt_PRE(bins, 0, 300);
+	Book_ljet_1_p4_Pt_PRE(bins, 0, 300);
+	Book_ljet_2_p4_Pt_PRE(bins, 0, 300);
+
+	///---------------------------------ljet_0 & ljet_1-----------------------------------///
+
+	Book_ljet_0_ljet_1_mass_PRE(bins, 0, 1500);
+	Book_ljet_0_ljet_1_mass(bins, 0, 1500);
+
 }
 
 // Pre-Selection cut functions (dummy cuts)
@@ -76,14 +91,14 @@ bool MC_Analysis::Zmumu2Jets_InitialCut() {
 	// Event reconstruction checking
 	
 	//Condition Checking
-	if (muon_0 != 0 && muon_1 != 0) { // if two muons or anti-muons, or one of each are found
+	if(n_muons ==2 ){ // if two muons or anti-muons, or one of each are found
 		two_muons = true;
 		if (muon_0_q != muon_1_q) muons_opposite_charges = true;  // if muon anti-muon pair found
 	}
 	
 	// bjet cuts
-	if (bjet_0 == 0 && bjet_1 == 0) no_bjets = true;  //If there are no bjets
-	if (ljet_0 !=0 && ljet_1 != 0) two_or_more_jets = true;  //If two or more jets were found
+	if (n_bjets == 0) no_bjets = true;  //If there are no bjets
+	if (n_jets >= 2) two_or_more_jets = true;  //If two or more jets were found
 
 	// If the conditions are met, don't cut
 	if (two_muons && two_or_more_jets && muons_opposite_charges && no_bjets) return false;
@@ -97,20 +112,35 @@ bool MC_Analysis::Zmumu2Jets_InitialCut() {
 void MC_Analysis::Zmumu2Jets_GenerateVariables() {
 
 	// Invariant Mass
-	muon_0_muon_1_Mass = InvariantMass(muon_0_p4, muon_1_p4);
+	muon_0_muon_1_mass = InvariantMass(muon_0_p4, muon_1_p4);
+	ljet_0_ljet_1_mass = InvariantMass(ljet_0_p4, ljet_1_p4);
 
 	//Delta R
 	DeltaR = DeltaRCalc(muon_0_p4, muon_1_p4);
+
+	// Combined muon transverse momentum
+	muon_0_muon_1_pt = CombinedTransverseMomentum(muon_0_p4, muon_1_p4);
+
 }
 
 // This function will fill the histograms that need to be filled BEFORE initial cuts are made
 void MC_Analysis::Zmumu2Jets_FillAllData_PreCut() {
 
 	//Invariant mass
-	h_muon_0_muon_1_mass_PRE->Fill(muon_0_muon_1_Mass);
+	h_muon_0_muon_1_mass_PRE->Fill(muon_0_muon_1_mass); // 2 muons
+	h_ljet_0_ljet_1_mass_PRE->Fill(ljet_0_ljet_1_mass); // 2 jets
+
+	// Combined muon transverse momentum
+	h_muon_0_muon_1_pt_PRE->Fill(muon_0_muon_1_pt);
 
 	// Delta R
 	h_DeltaR_PRE->Fill(DeltaR);
+
+	//ljet transverse momenta
+	h_ljet_0_p4_Pt_PRE->Fill(ljet_0_p4->Pt());
+	h_ljet_1_p4_Pt_PRE->Fill(ljet_1_p4->Pt());
+	h_ljet_2_p4_Pt_PRE->Fill(ljet_2_p4->Pt());
+
 }
 
 // Analysis starts here
@@ -118,20 +148,30 @@ void MC_Analysis::Zmumu2Jets_FillAllData_PreCut() {
 // Selection cut functions (more sophistocated cuts)
 bool MC_Analysis::Zmumu2Jets_Cut() {
 
-	// search region cuts from Section 6, page 7, REF: ATLAS doi:10.1007/JHEP04(2014)031
-	// Z boson defined as 2 opp charged same flavour leptons with a dilepton invariant mass of 81 < m_{ll} < 101 GeV
-	// Transverse momentum of dilepton pair p_T^{ll} > 20GeV
+	// Initialise bool conditions
+	bool combined_lepton_pt = false;
+	bool ljet_0_pt_greater = false;
+	bool ljet_1_pt_greater = false;
+	bool leading_jets_invariant_mass = false;
+
+	// Condition Checking
 	
+	// REF: ATLAS doi:10.1007/JHEP04(2014)031: search region cuts from Section 6, page 7
+	if (muon_0_muon_1_pt > 20) combined_lepton_pt = true; // Transverse momentum of dilepton pair p_T^{ll} > 20GeV
 	// At least 2 jets that satisfy p_T^{j1} > 55 GeV, p_T^{j2} > 45 GeV 
+	if (ljet_0_p4->Pt() > 50) ljet_0_pt_greater = true;
+	if (ljet_1_p4->Pt() > 50) ljet_1_pt_greater = true;
 	// j1 j2 highest and second highest order transverse momentum jets
-	// invariant mass of 2 leading jets required to satisfy m_jj > 250 GeV
+	if (ljet_0_ljet_1_mass > 250) leading_jets_invariant_mass = true; // invariant mass of 2 leading jets required to satisfy m_jj > 250 GeV
+
+	// additional cuts to add from same ref
+	// Z boson defined as 2 opp charged same flavour leptons with a dilepton invariant mass of 81 < m_{ll} < 101 GeV	
 	// no additional jest with p_T > 25 GeV in rapidity interval between two leading jets
 	// p_T balance required to be less than 0.15
 
-	//Condition Checking
-
 	//If the conditions are met, don't cut
-	if (true) return false;	
+	if (leading_jets_invariant_mass && ljet_0_pt_greater && ljet_1_pt_greater && combined_lepton_pt) return false;	
+
 	//Otherwise, cut
 	return true;
 
@@ -155,14 +195,26 @@ void MC_Analysis::Zmumu2Jets_FillAllData_PostCut() {
 	h_muon_0_iso_topoetcone30->Fill(muon_0_iso_topoetcone30);
 	h_muon_0_iso_topoetcone40->Fill(muon_0_iso_topoetcone40);
 
-	// muon_0_p4.Pt
-	h_muon_0_p4_Pt->Fill(muon_0_p4->Pt()); // to access the Pt Lorentz Vector
+	// muon 0 momentum
+	h_muon_0_p4_Pt->Fill(muon_0_p4->Pt());
 
 	// Invariant mass
-	h_muon_0_muon_1_mass->Fill(muon_0_muon_1_Mass);
+	h_muon_0_muon_1_mass->Fill(muon_0_muon_1_mass); // two leptons
+	h_ljet_0_ljet_1_mass->Fill(ljet_0_ljet_1_mass); // two jets
+
+	// Combined lepton (muon) pt
+	h_muon_0_muon_1_pt->Fill(muon_0_muon_1_pt);
 
 	// Delta R
 	h_DeltaR->Fill(DeltaR);
+
+	//ljet transverse momenta
+	h_ljet_0_p4_Pt->Fill(ljet_0_p4->Pt());
+	h_ljet_1_p4_Pt->Fill(ljet_1_p4->Pt());
+	h_ljet_2_p4_Pt->Fill(ljet_2_p4->Pt());
+	
+	// ljet rapidity
+	// muon rapidity 
 
 }
 
@@ -199,12 +251,31 @@ void MC_Analysis::Zmumu2Jets_DrawHistos() {
 	DrawHistogram(h_muon_0_p4_Pt, "h_muon_0_p4_Pt", "h_muon_0_p4_Pt", "", 600, 400, true, "h_muon_0_p4_Pt.pdf", AnalysisType);
 
 	// muon 0 & muon 1 histograms
-	DrawHistogram(h_muon_0_muon_1_mass_PRE, "h_muon_0_muon_1_mass_PRE", "h_elec_0_elec_1_mass_PRE", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_muon_0_muon_1_mass_PRE.pdf", AnalysisType);
+	DrawHistogram(h_muon_0_muon_1_mass_PRE, "h_muon_0_muon_1_mass_PRE", "h_muon_0_muon_1_mass_PRE", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_muon_0_muon_1_mass_PRE.pdf", AnalysisType);
 	DrawHistogram(h_muon_0_muon_1_mass, "h_muon_0_muon_1_mass", "h_muon_0_muon_1_mass", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_muon_0_muon_1_mass.pdf", AnalysisType);
 
 	// Delta R Histograms
 	DrawHistogram(h_DeltaR_PRE, "h_DeltaR_PRE", "h_DeltaR_PRE_muon", "", 600, 400, false, "h_DeltaR_PRE_muon.pdf", AnalysisType);
 	DrawHistogram(h_DeltaR, "h_DeltaR", "h_DeltaR_muon", "", 600, 400, false, "h_DeltaR_muon.pdf", AnalysisType);
+
+	// combined lepton momentum
+	DrawHistogram(h_muon_0_muon_1_mass_PRE, "h_muon_0_muon_1_mass_PRE", "h_muon_0_muon_1_mass_PRE_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_muon_0_muon_1_mass_PRE_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_muon_0_muon_1_mass, "h_muon_0_muon_1_mass", "h_muon_0_muon_1_mass_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_muon_0_muon_1_mass_Zmumu2Jets.pdf", AnalysisType);
+
+	// leading jets invariant masses
+	DrawHistogram(h_ljet_0_ljet_1_mass_PRE, "h_ljet_0_ljet_1_mass_PRE", "h_ljet_0_ljet_1_mass_PRE_Zmumu2Jets", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_ljet_0_ljet_1_mass_PRE_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_0_ljet_1_mass, "h_ljet_0_ljet_1_mass", "h_ljet_0_ljet_1_mass_Zmumu2Jets", "Invariant Mass [GeV/c^{2}]", 600, 400, false, "h_ljet_0_ljet_1_mass_Zmumu2Jets.pdf", AnalysisType);
+
+	// ljet transverse momenta
+	// PRE selection cuts
+	DrawHistogram(h_ljet_0_p4_Pt_PRE, "h_ljet_0_p4_Pt_PRE", "h_ljet_0_p4_Pt_PRE_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_0_p4_Pt_PRE_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_1_p4_Pt_PRE, "h_ljet_1_p4_Pt_PRE", "h_ljet_1_p4_Pt_PRE_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_1_p4_Pt_PRE_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_2_p4_Pt_PRE, "h_ljet_2_p4_Pt_PRE", "h_ljet_2_p4_Pt_PRE_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_2_p4_Pt_PRE_Zmumu2Jets.pdf", AnalysisType);
+	// Post selection cuts
+	DrawHistogram(h_ljet_0_p4_Pt, "h_ljet_0_p4_Pt", "h_ljet_0_p4_Pt_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_0_p4_Pt_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_1_p4_Pt, "h_ljet_1_p4_Pt", "h_ljet_1_p4_Pt_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_1_p4_Pt_Zmumu2Jets.pdf", AnalysisType);
+	DrawHistogram(h_ljet_2_p4_Pt, "h_ljet_2_p4_Pt", "h_ljet_2_p4_Pt_Zmumu2Jets", "Momentum [GeV/c]", 600, 400, false, "h_ljet_2_p4_Pt_Zmumu2Jets.pdf", AnalysisType);
+
 
 
 }


### PR DESCRIPTION
Changed so all variables have same names (couple capitals and others not, was getting confusing so corrected, also copied over to muon analysis so cuts are implemented from the ATLAS paper, included the reference for this paper in the code so users can see where they have come from