### PR TITLE
Fixes to phi interval chech and MET_Centrality in order to account fo…

### DIFF
--- a/Code/Custom_Histogram_Names.txt
+++ b/Code/Custom_Histogram_Names.txt
@@ -21,4 +21,8 @@ MET_Centrality:Missing transversE Momentum centrality
 neutrino_0_pt:missing energy of neutrino 1
 neutrino_1_pt:missing energy of neutrino 2
 MET_Type_Favour:Whether the missing energy is directed more towards the hadronic tau or the other lepton (e or m)
+##RECONSTRUCTED
 lep_0_lep_1_mass_reconstructed: reconstructed Z mass with neutrino and z candidates
+DeltaR_reconstructed:Distance in R space between two leptons (reconstructed with missing neutrino energy included)
+lep_0_lep_1_pt_reconstructed:Combined transverse momentum of lepton 0 and lepton 1 (reconstructed with missing neutrino energy included)
+Centrality_reconstructed:Centrality of pseudorapidity of Z boson between two leading jets (reconstructed with missing neutrino energy included)

--- a/Code/Headers/Analysis.h
+++ b/Code/Headers/Analysis.h
@@ -32,7 +32,7 @@ void MC_Analysis::BookHistos() {
 	int pT_balance_Min = 0, pT_balance_Max = 1;
 	int pT_balance_3_Min = 0, pT_balance_3_Max = 1;
 	int Centrality_Min = -8, Centrality_Max = 8;
-	int MET_Centrality_Min = -16, MET_Centrality_Max = 16;
+	int MET_Centrality_Min = -4, MET_Centrality_Max = 4;
 	double RapidityDijet_Min = 0, RapidityDijet_Max = 4.5;
 	double RapidityDilepton_Min = 0, RapidityDilepton_Max = 4.5;
 	int lep_0_lep_1_mass_Min = 0, lep_0_lep_1_mass_Max = 200;
@@ -48,7 +48,11 @@ void MC_Analysis::BookHistos() {
 	int neutrino_0_pt_Min = 0, neutrino_0_pt_Max = 1000;
 	int neutrino_1_pt_Min = 0, neutrino_1_pt_Max = 1000;
 	int MET_Type_Favour_Min = -1, MET_Type_Favour_Max = 2;
-  int lep_0_lep_1_mass_reconstructed_Min =0, lep_0_lep_1_mass_reconstructed_Max =200;
+
+  	int lep_0_lep_1_mass_reconstructed_Min = 0, lep_0_lep_1_mass_reconstructed_Max = 200;
+	int DeltaR_reconstructed_Min = 0, DeltaR_reconstructed_Max = 10;
+	int lep_0_lep_1_pt_reconstructed_Min = 0, lep_0_lep_1_pt_reconstructed_Max = 300;
+	int Centrality_reconstructed_Min = -8, Centrality_reconstructed_Max = 8;
 
 	/////----------------------------------BOOKINGS------------------------------------/////
 
@@ -305,34 +309,6 @@ bool MC_Analysis::InitialCut(bool bjets) {
 ////////////////////////////////////////////////////////////////////////////////////////
 void MC_Analysis::GenerateVariables() {
 
-	//Invariant Mass
-	lep_0_lep_1_mass = InvariantMass(lep_0_p4, lep_1_p4);
-	jet_0_jet_1_mass = InvariantMass(jet_0_p4, jet_1_p4);
-
-	//Delta R
-	DeltaR = DeltaRCalc(lep_0_p4, lep_1_p4);
-
-	// Rapidity of dilepton pair
-	RapidityDilepton = RapidityDisomething(lep_0_p4, lep_1_p4);
-
-	// Rapidity of dijet pair
-	RapidityDijet = RapidityDisomething(jet_0_p4, jet_1_p4);
-
-	//Combined Lepton momentum
-	lep_0_lep_1_pt = CombinedTransverseMomentum(lep_0_p4, lep_1_p4);
-
-	// p_T_Balance 
-	pT_balance = pTBalanceCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4);
-	
-	// p_T_Balance_3
-	pT_balance_3 = pTBalanceThreeCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4, jet_2_p4);
-	
-	// Centrality of Z boson between two leading jets calc using rapidity
-	Centrality = CentralityCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4);
-
-	//Final Weighting
-	final_weighting = Luminosity_Weight * weight_total;
-	
 	// Missing transverse momentum centrality
 	MET_Centrality = METCentrality(met_reco_p4, lep_0_p4, lep_1_p4);
 
@@ -357,11 +333,41 @@ void MC_Analysis::GenerateVariables() {
 	TLorentzVector* neutrino_1_TLV = neutrino_TLV(neutrino_1_x_p, neutrino_1_y_p, neutrino_1_z_p); // TLorentzVector (TLV) 4 momentum px,py,pz,E (E=p_tot) of neutrino 2
 
 	// reconstruct tau candidate with tau lepton and neutrino
-	TLorentzVector* reconstructed_tau_0_TLV = reconstucted_tau_candidate_TLV(lep_0_p4, neutrino_0_TLV); // new TLV for tau candidate with lepton 0 and neutrino 0
-	TLorentzVector* reconstructed_tau_1_TLV = reconstucted_tau_candidate_TLV(lep_1_p4, neutrino_1_TLV); // new TLV for tau candidate with lepton 1 and neutrino 1
+	TLorentzVector* lep_0_reco_p4 = reconstucted_tau_candidate_TLV(lep_0_p4, neutrino_0_TLV); // new TLV for tau candidate with lepton 0 and neutrino 0
+	TLorentzVector* lep_1_reco_p4 = reconstucted_tau_candidate_TLV(lep_1_p4, neutrino_1_TLV); // new TLV for tau candidate with lepton 1 and neutrino 1
 	
-	// invariant mass of the Z boson with new reconstructed neutrino
-	lep_0_lep_1_mass_reconstructed = InvariantMass(reconstructed_tau_0_TLV, reconstructed_tau_1_TLV);
+	//Invariant Mass
+	lep_0_lep_1_mass = InvariantMass(lep_0_p4, lep_1_p4);
+	lep_0_lep_1_mass_reconstructed = InvariantMass(lep_0_reco_p4 , lep_1_reco_p4);
+
+	jet_0_jet_1_mass = InvariantMass(jet_0_p4, jet_1_p4);
+
+	//Delta R
+	DeltaR = DeltaRCalc(lep_0_p4, lep_1_p4);
+	DeltaR_reconstructed = DeltaRCalc(lep_0_reco_p4, lep_1_reco_p4);
+
+	// Rapidity of dilepton pair
+	RapidityDilepton = RapidityDisomething(lep_0_p4, lep_1_p4);
+
+	// Rapidity of dijet pair
+	RapidityDijet = RapidityDisomething(jet_0_p4, jet_1_p4);
+
+	//Combined Lepton momentum
+	lep_0_lep_1_pt = CombinedTransverseMomentum(lep_0_p4, lep_1_p4);
+
+	// p_T_Balance 
+	pT_balance = pTBalanceCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4);
+	
+	// p_T_Balance_3
+	pT_balance_3 = pTBalanceThreeCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4, jet_2_p4);
+	
+	// Centrality of Z boson between two leading jets calc using rapidity
+	Centrality = CentralityCalc(lep_0_p4, lep_1_p4, jet_0_p4, jet_1_p4);
+	Centrality_reconstructed = CentralityCalc(lep_0_reco_p4, lep_1_reco_p4, jet_0_p4, jet_1_p4);
+
+	//Final Weighting
+	final_weighting = Luminosity_Weight * weight_total;
+	
 }	
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -489,10 +495,11 @@ bool MC_Analysis::Cuts(string region) {
 	bool common_cuts = false;	//The common cuts are false initially
 
 	// common cuts for "Tau"
-	if (AnalysisType == "ElectonMuon" || AnalysisType == "ElectronTau" || AnalysisType == "MuonTau"){
+	if (AnalysisType == "ElectronMuon" || AnalysisType == "ElectronTau" || AnalysisType == "MuonTau"){
 
 		//This is only here in order to see the full mass spectrum represented in the rest of the cuts, and should be changed when appropriate
 		Z_mass_condition = true;
+		
 	
 		//Work out if the common cuts are true here
 	 	if (Z_mass_condition && combined_lepton_pt && ljet_0_pt_greater && ljet_1_pt_greater && leading_jets_invariant_mass && ptvarcone_40_0 && ptvarcone_40_1 && phi_int_condition) {

--- a/Code/Headers/Histo_Book_Definitions_AutoGen_Custom.h
+++ b/Code/Headers/Histo_Book_Definitions_AutoGen_Custom.h
@@ -234,6 +234,8 @@ vector<TH1F*>	hv_MET_Type_Favour; // HISTOGRAM VECTOR
 
 vector<string>	hv_MET_Type_Favour_names; // HISTOGRAM NAME VECTOR
 
+/// ------------------- RECONSTRUCTED ---------------- ///
+
 // --  reconstructed Z mass with neutrino and z candidates
 double lep_0_lep_1_mass_reconstructed;
 
@@ -246,5 +248,44 @@ TH1F	*h_lep_0_lep_1_mass_reconstructed_BJET; // BJET VERSION
 vector<TH1F*>	hv_lep_0_lep_1_mass_reconstructed; // HISTOGRAM VECTOR
 
 vector<string>	hv_lep_0_lep_1_mass_reconstructed_names; // HISTOGRAM NAME VECTOR
+
+// -- Distance in R space between two leptons (reconstructed with missing neutrino energy included)
+double DeltaR_reconstructed;
+
+virtual void Book_DeltaR_reconstructed(int bins, double min, double max);
+TH1F	*h_DeltaR_reconstructed; // SEARCH VERSION
+TH1F	*h_DeltaR_reconstructed_PRE; // PRE VERSION
+TH1F	*h_DeltaR_reconstructed_CONTROL; // CONTROL VERSION
+TH1F	*h_DeltaR_reconstructed_EXCEPT; // EXCEPT VERSION
+TH1F	*h_DeltaR_reconstructed_BJET; // BJET VERSION
+vector<TH1F*>	hv_DeltaR_reconstructed; // HISTOGRAM VECTOR
+
+vector<string>	hv_DeltaR_reconstructed_names; // HISTOGRAM NAME VECTOR
+
+// -- Combined transverse momentum of lepton 0 and lepton 1 (reconstructed with missing neutrino energy included)
+double lep_0_lep_1_pt_reconstructed;
+
+virtual void Book_lep_0_lep_1_pt_reconstructed(int bins, double min, double max);
+TH1F	*h_lep_0_lep_1_pt_reconstructed; // SEARCH VERSION
+TH1F	*h_lep_0_lep_1_pt_reconstructed_PRE; // PRE VERSION
+TH1F	*h_lep_0_lep_1_pt_reconstructed_CONTROL; // CONTROL VERSION
+TH1F	*h_lep_0_lep_1_pt_reconstructed_EXCEPT; // EXCEPT VERSION
+TH1F	*h_lep_0_lep_1_pt_reconstructed_BJET; // BJET VERSION
+vector<TH1F*>	hv_lep_0_lep_1_pt_reconstructed; // HISTOGRAM VECTOR
+
+vector<string>	hv_lep_0_lep_1_pt_reconstructed_names; // HISTOGRAM NAME VECTOR
+
+// -- Centrality of pseudorapidity of Z boson between two leading jets (reconstructed with missing neutrino energy included)
+double Centrality_reconstructed;
+
+virtual void Book_Centrality_reconstructed(int bins, double min, double max);
+TH1F	*h_Centrality_reconstructed; // SEARCH VERSION
+TH1F	*h_Centrality_reconstructed_PRE; // PRE VERSION
+TH1F	*h_Centrality_reconstructed_CONTROL; // CONTROL VERSION
+TH1F	*h_Centrality_reconstructed_EXCEPT; // EXCEPT VERSION
+TH1F	*h_Centrality_reconstructed_BJET; // BJET VERSION
+vector<TH1F*>	hv_Centrality_reconstructed; // HISTOGRAM VECTOR
+
+vector<string>	hv_Centrality_reconstructed_names; // HISTOGRAM NAME VECTOR
 
 #endif

--- a/Code/Headers/Histo_Book_Functions_AutoGen_Custom.h
+++ b/Code/Headers/Histo_Book_Functions_AutoGen_Custom.h
@@ -387,6 +387,8 @@ void MC_Analysis::Book_MET_Type_Favour(int bins, double min, double max) {
 }
 
 
+/// ------------------- RECONSTRUCTED ---------------- ///
+
 // --  reconstructed Z mass with neutrino and z candidates
 void MC_Analysis::Book_lep_0_lep_1_mass_reconstructed(int bins, double min, double max) {
 	h_lep_0_lep_1_mass_reconstructed = new TH1F("h_lep_0_lep_1_mass_reconstructed", "", bins, min, max);
@@ -406,6 +408,72 @@ void MC_Analysis::Book_lep_0_lep_1_mass_reconstructed(int bins, double min, doub
 	hv_lep_0_lep_1_mass_reconstructed_names.push_back("h_lep_0_lep_1_mass_reconstructed_EXCEPT");
 	hv_lep_0_lep_1_mass_reconstructed_names.push_back("h_lep_0_lep_1_mass_reconstructed_PRE");
 	hv_lep_0_lep_1_mass_reconstructed_names.push_back("h_lep_0_lep_1_mass_reconstructed_BJET");
+}
+
+
+// -- Distance in R space between two leptons (reconstructed with missing neutrino energy included)
+void MC_Analysis::Book_DeltaR_reconstructed(int bins, double min, double max) {
+	h_DeltaR_reconstructed = new TH1F("h_DeltaR_reconstructed", "", bins, min, max);
+	h_DeltaR_reconstructed_PRE = new TH1F("h_DeltaR_reconstructed_PRE", "", bins, min, max);
+	h_DeltaR_reconstructed_CONTROL = new TH1F("h_DeltaR_reconstructed_CONTROL", "", bins, min, max);
+	h_DeltaR_reconstructed_EXCEPT = new TH1F("h_DeltaR_reconstructed_EXCEPT", "", bins, min, max);
+	h_DeltaR_reconstructed_BJET = new TH1F("h_DeltaR_reconstructed_BJET", "", bins, min, max);
+
+	hv_DeltaR_reconstructed.push_back(h_DeltaR_reconstructed);
+	hv_DeltaR_reconstructed.push_back(h_DeltaR_reconstructed_CONTROL);
+	hv_DeltaR_reconstructed.push_back(h_DeltaR_reconstructed_EXCEPT);
+	hv_DeltaR_reconstructed.push_back(h_DeltaR_reconstructed_PRE);
+	hv_DeltaR_reconstructed.push_back(h_DeltaR_reconstructed_BJET);
+
+	hv_DeltaR_reconstructed_names.push_back("h_DeltaR_reconstructed");
+	hv_DeltaR_reconstructed_names.push_back("h_DeltaR_reconstructed_CONTROL");
+	hv_DeltaR_reconstructed_names.push_back("h_DeltaR_reconstructed_EXCEPT");
+	hv_DeltaR_reconstructed_names.push_back("h_DeltaR_reconstructed_PRE");
+	hv_DeltaR_reconstructed_names.push_back("h_DeltaR_reconstructed_BJET");
+}
+
+
+// -- Combined transverse momentum of lepton 0 and lepton 1 (reconstructed with missing neutrino energy included)
+void MC_Analysis::Book_lep_0_lep_1_pt_reconstructed(int bins, double min, double max) {
+	h_lep_0_lep_1_pt_reconstructed = new TH1F("h_lep_0_lep_1_pt_reconstructed", "", bins, min, max);
+	h_lep_0_lep_1_pt_reconstructed_PRE = new TH1F("h_lep_0_lep_1_pt_reconstructed_PRE", "", bins, min, max);
+	h_lep_0_lep_1_pt_reconstructed_CONTROL = new TH1F("h_lep_0_lep_1_pt_reconstructed_CONTROL", "", bins, min, max);
+	h_lep_0_lep_1_pt_reconstructed_EXCEPT = new TH1F("h_lep_0_lep_1_pt_reconstructed_EXCEPT", "", bins, min, max);
+	h_lep_0_lep_1_pt_reconstructed_BJET = new TH1F("h_lep_0_lep_1_pt_reconstructed_BJET", "", bins, min, max);
+
+	hv_lep_0_lep_1_pt_reconstructed.push_back(h_lep_0_lep_1_pt_reconstructed);
+	hv_lep_0_lep_1_pt_reconstructed.push_back(h_lep_0_lep_1_pt_reconstructed_CONTROL);
+	hv_lep_0_lep_1_pt_reconstructed.push_back(h_lep_0_lep_1_pt_reconstructed_EXCEPT);
+	hv_lep_0_lep_1_pt_reconstructed.push_back(h_lep_0_lep_1_pt_reconstructed_PRE);
+	hv_lep_0_lep_1_pt_reconstructed.push_back(h_lep_0_lep_1_pt_reconstructed_BJET);
+
+	hv_lep_0_lep_1_pt_reconstructed_names.push_back("h_lep_0_lep_1_pt_reconstructed");
+	hv_lep_0_lep_1_pt_reconstructed_names.push_back("h_lep_0_lep_1_pt_reconstructed_CONTROL");
+	hv_lep_0_lep_1_pt_reconstructed_names.push_back("h_lep_0_lep_1_pt_reconstructed_EXCEPT");
+	hv_lep_0_lep_1_pt_reconstructed_names.push_back("h_lep_0_lep_1_pt_reconstructed_PRE");
+	hv_lep_0_lep_1_pt_reconstructed_names.push_back("h_lep_0_lep_1_pt_reconstructed_BJET");
+}
+
+
+// -- Centrality of pseudorapidity of Z boson between two leading jets (reconstructed with missing neutrino energy included)
+void MC_Analysis::Book_Centrality_reconstructed(int bins, double min, double max) {
+	h_Centrality_reconstructed = new TH1F("h_Centrality_reconstructed", "", bins, min, max);
+	h_Centrality_reconstructed_PRE = new TH1F("h_Centrality_reconstructed_PRE", "", bins, min, max);
+	h_Centrality_reconstructed_CONTROL = new TH1F("h_Centrality_reconstructed_CONTROL", "", bins, min, max);
+	h_Centrality_reconstructed_EXCEPT = new TH1F("h_Centrality_reconstructed_EXCEPT", "", bins, min, max);
+	h_Centrality_reconstructed_BJET = new TH1F("h_Centrality_reconstructed_BJET", "", bins, min, max);
+
+	hv_Centrality_reconstructed.push_back(h_Centrality_reconstructed);
+	hv_Centrality_reconstructed.push_back(h_Centrality_reconstructed_CONTROL);
+	hv_Centrality_reconstructed.push_back(h_Centrality_reconstructed_EXCEPT);
+	hv_Centrality_reconstructed.push_back(h_Centrality_reconstructed_PRE);
+	hv_Centrality_reconstructed.push_back(h_Centrality_reconstructed_BJET);
+
+	hv_Centrality_reconstructed_names.push_back("h_Centrality_reconstructed");
+	hv_Centrality_reconstructed_names.push_back("h_Centrality_reconstructed_CONTROL");
+	hv_Centrality_reconstructed_names.push_back("h_Centrality_reconstructed_EXCEPT");
+	hv_Centrality_reconstructed_names.push_back("h_Centrality_reconstructed_PRE");
+	hv_Centrality_reconstructed_names.push_back("h_Centrality_reconstructed_BJET");
 }
 
 

--- a/Code/Headers/MC_Analysis.h
+++ b/Code/Headers/MC_Analysis.h
@@ -18,6 +18,7 @@
 // Header file for the classes stored in the TTree if any.
 #include "TLorentzVector.h"
 #include "TVector3.h"
+const double pi = 3.14159265359;
 
 class MC_Analysis {
 public :

--- a/Code/Headers/_BookHistos.h
+++ b/Code/Headers/_BookHistos.h
@@ -112,3 +112,12 @@
 	//Histogram Bookings for lep_0_lep_1_mass_reconstructed
 	Book_lep_0_lep_1_mass_reconstructed(bins, lep_0_lep_1_mass_reconstructed_Min, lep_0_lep_1_mass_reconstructed_Max);
 
+	//Histogram Bookings for DeltaR_reconstructed
+	Book_DeltaR_reconstructed(bins, DeltaR_reconstructed_Min, DeltaR_reconstructed_Max);
+
+	//Histogram Bookings for lep_0_lep_1_pt_reconstructed
+	Book_lep_0_lep_1_pt_reconstructed(bins, lep_0_lep_1_pt_reconstructed_Min, lep_0_lep_1_pt_reconstructed_Max);
+
+	//Histogram Bookings for Centrality_reconstructed
+	Book_Centrality_reconstructed(bins, Centrality_reconstructed_Min, Centrality_reconstructed_Max);
+


### PR DESCRIPTION
…r when delta phi is greater than 180. Added recosntructed histograms for Delta R, Dilepton Transverse Momentum, and Centrality, as they all use leptons in their calculations. Also made minor adjustments to drawing functions with regards to max and min histogram values, and made a change to the rapidity disomething function so that it uses the vector sum for rapidity, rather than the magnitude sum (KEEP AN EYE ON THIS)